### PR TITLE
Add the entry-point of `mikku pr` commands

### DIFF
--- a/github.go
+++ b/github.go
@@ -144,13 +144,13 @@ func (s *GitHubService) getMergedPRsAfter(repo string, after time.Time) ([]*gith
 	return prList, nil
 }
 
-// GetManifestFile fetches the file from GitHub and return it encoded by base64
-func (s *GitHubService) GetManifestFile(repo, filePath string) (string, error) {
+// GetFile fetches the file from GitHub and return it encoded by base64
+func (s *GitHubService) GetFile(repo, filePath string) (string, error) {
 	return "", errors.New("must be implemented")
 }
 
-// PushManifestFile pushes the updated file
-func (s *GitHubService) PushManifestFile(repo, filePath, branch string, body []byte) error {
+// PushFile pushes the updated file
+func (s *GitHubService) PushFile(repo, filePath, branch string, body []byte) error {
 	return errors.New("must be implemented")
 }
 

--- a/mikku.go
+++ b/mikku.go
@@ -84,7 +84,7 @@ func PullRequest(repo, manifestRepo, pathToManifestFile, imageName string) error
 
 	svc := NewGitHubService(cfg.GitHubOwner, cfg.GitHubAccessToken)
 
-	encodedFile, err := svc.GetManifestFile(manifestRepo, pathToManifestFile)
+	encodedFile, err := svc.GetFile(manifestRepo, pathToManifestFile)
 	if err != nil {
 		return fmt.Errorf("failed to get manifest file: %w", err)
 	}
@@ -114,7 +114,7 @@ func PullRequest(repo, manifestRepo, pathToManifestFile, imageName string) error
 		return fmt.Errorf("failed to create branch: %w", err)
 	}
 
-	if err := svc.PushManifestFile(manifestRepo, pathToManifestFile, branch, []byte(replacedFIle)); err != nil {
+	if err := svc.PushFile(manifestRepo, pathToManifestFile, branch, []byte(replacedFIle)); err != nil {
 		return fmt.Errorf("failed to push updated the manifest file: %w", err)
 	}
 


### PR DESCRIPTION
## What
- Add only function definitions using the creation of pull requests
- Add the entry-point of `mikku pr` commands

## Out of Scope
- Implementation of GitHub access functions
- Tag replace function in the manifest file